### PR TITLE
Add `find` command

### DIFF
--- a/src/main/java/ymfc/commands/FindCommand.java
+++ b/src/main/java/ymfc/commands/FindCommand.java
@@ -1,0 +1,69 @@
+package ymfc.commands;
+
+import ymfc.recipe.Recipe;
+import ymfc.recipelist.RecipeList;
+import ymfc.storage.Storage;
+import ymfc.ui.Ui;
+
+import java.util.ArrayList;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+
+import static ymfc.YMFC.logger;
+
+public class FindCommand extends Command {
+    public static final String USAGE_EXAMPLE = """
+            Use example:
+            \t find spaghetti // Default: find by name
+            \t find i/tomato
+            \t find ns/tomato
+            \t find nis/tomato
+            
+            Note that any combination of "nis" stands for "Name, Ingredients and Steps".
+            """;
+
+    private String query;
+    private boolean isByName = true;
+    private boolean isByIngredient = false;
+    private boolean isByStep = false;
+
+
+    public FindCommand(String query) {
+        this.query = query;
+    }
+
+    public FindCommand(String query, boolean isByName, boolean isByIngredient, boolean isByStep) {
+        this.query = query;
+        this.isByName = isByName;
+        this.isByIngredient = isByIngredient;
+        this.isByStep = isByStep;
+    }
+
+    @Override
+    public void execute(RecipeList recipes, Ui ui, Storage storage) throws Exception {
+        logger.log(Level.FINEST, "Executing FindCommand");
+        ArrayList<Recipe> results = recipes.getRecipes()
+                .stream()
+                .filter((Recipe recipe) -> isQueryFoundInName(recipe) |
+                        isFoundInIngredients(recipe) |
+                        isFoundInSteps(recipe)
+                )
+                .collect(Collectors.toCollection(ArrayList::new));
+        ui.printFind(results, results.size());
+        logger.log(Level.FINEST, "FindCommand successfully executed");
+    }
+
+    private boolean isFoundInSteps(Recipe recipe) {
+        return isByStep &
+                recipe.getSteps().stream().anyMatch(s -> s.contains(query));
+    }
+
+    private boolean isFoundInIngredients(Recipe recipe) {
+        return isByIngredient &
+                recipe.getIngredients().stream().anyMatch(s -> s.contains(query));
+    }
+
+    private boolean isQueryFoundInName(Recipe recipe) {
+        return isByName & recipe.getName().contains(query);
+    }
+}

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -8,6 +8,7 @@ import ymfc.commands.EditCommand;
 import ymfc.commands.HelpCommand;
 import ymfc.commands.ListCommand;
 import ymfc.commands.SortCommand;
+import ymfc.commands.FindCommand;
 import ymfc.exception.InvalidArgumentException;
 import ymfc.exception.InvalidCommandException;
 import ymfc.recipe.Recipe;
@@ -59,6 +60,8 @@ public final class Parser {
             return getSortCommand(args);
         case "edit":
             return getEditCommand(args);
+        case "find":
+            return getFindCommand(args);
         default:
             throw new InvalidCommandException("Invalid command: " + command + "\ntype \"help\" for assistance");
         }
@@ -233,5 +236,32 @@ public final class Parser {
         } else {
             return new EditCommand(new Recipe(name, ingreds, steps));
         }
+    }
+
+    private static Command getFindCommand(String args) throws InvalidArgumentException {
+        final Pattern findCommandPattern =
+                // Options to feed into findCommand, could be null
+                // Length of 1 to 3, consist of only "nNiIsS", must ends with /
+                Pattern.compile("(?<options>[nNiIsS]{1,3}/)?" +
+                        // Query command
+                        "(?<query>[^/]+)");
+        args = args.trim();
+        Matcher m = findCommandPattern.matcher(args);
+        if (!m.matches()) {
+            throw new InvalidArgumentException("Invalid argument(s): " + args + "\n" + FindCommand.USAGE_EXAMPLE);
+        }
+
+        String query = m.group("query");
+        String options = m.group("options");
+        if (options == null) {
+            return new FindCommand(query); // Default case, no option provided
+        }
+
+        options = options.trim();
+        return new FindCommand(query,
+                options.contains("n") | options.contains("n"),
+                options.contains("i") | options.contains("I"),
+                options.contains("s") | options.contains("S")
+        );
     }
 }

--- a/src/main/java/ymfc/ui/Ui.java
+++ b/src/main/java/ymfc/ui/Ui.java
@@ -115,11 +115,20 @@ public class Ui {
     public void printList(ArrayList<Recipe> list, int listCount) {
         System.out.println(line);
         System.out.println("\tHere's everything in my collection so far:");
+        printListWithOrder(list, listCount);
+        System.out.println(line);
+    }
+
+    /**
+     * Display list of recipes with order of each recipe
+     * @param list ArrayList of recipes to be displayed
+     * @param listCount Integer representing total number of recipes in <code>list</code>
+     */
+    private void printListWithOrder(ArrayList<Recipe> list, int listCount) {
         for (int i = 0; i < listCount; i++) {
             System.out.println("\t" + (i + 1) + "." + list.get(i));
             System.out.println(line);
         }
-        System.out.println(line);
     }
 
     /**
@@ -138,10 +147,17 @@ public class Ui {
         System.out.println(line);
     }
 
-
     public void printHelp() {
         System.out.println(line);
         System.out.println("Commands: help, delete, add, list");
+        System.out.println(line);
+    }
+
+    public void printFind(ArrayList<Recipe> list, int listCount) {
+        System.out.println(line);
+        System.out.println("\tHere's everything that I've found so far:");
+        printListWithOrder(list, listCount);
+        System.out.println("\tTotal: " + listCount + " recipes found!");
         System.out.println(line);
     }
 }

--- a/src/test/java/ymfc/parser/ParserTest.java
+++ b/src/test/java/ymfc/parser/ParserTest.java
@@ -168,5 +168,17 @@ class ParserTest {
         assertThrows(InvalidArgumentException.class, () -> parseCommand(command));
     }
 
-
+    @ParameterizedTest
+    @DisplayName("parseCommand_findCommand_invalidArgumentsExceptionThrown")
+    @ValueSource(strings = {
+        "find nNIsS/query",     // Invalid options (more than 3 characters)
+        "find nX/query",        // Invalid options (contains an invalid character)
+        "find nNi/",            // Invalid query (empty query after `/`)
+        "find nNi/foo/bar",     // Invalid query (contains `/` in query part)
+        "find /foo",            // Invalid query (no options, but query starts with `/`)
+        "find nNi/"             // Missing query (no query provided after `/`)
+    })
+    void parseCommand_findCommand_invalidArgumentsExceptionThrown(String command) {
+        assertThrows(InvalidArgumentException.class, () -> parseCommand(command));
+    }
 }


### PR DESCRIPTION
This PR resolves #24, with some additions on top
### Feature:
- `find` command: `find [<options>/] <query>`
  + `options` could be any combinations of "nNiIsS" with max length of 3, ends with a forward slash.

### Changes:
- Add `printFind()` to `UI.java`.
- Extract `printListwithOrder()` to a separate method for more flexibility.
- test: JUnit exception expected tests for find command

### Todo list:
- Edge cases for `options` (e.g: `find nNn/nut`)
- JUnit tests for success runs