### PR TITLE
Close Issue #72 and #76

### DIFF
--- a/src/main/java/ymfc/commands/DeleteIngredientCommand.java
+++ b/src/main/java/ymfc/commands/DeleteIngredientCommand.java
@@ -1,0 +1,47 @@
+package ymfc.commands;
+
+import ymfc.exception.InvalidArgumentException;
+import ymfc.list.IngredientList;
+import ymfc.list.RecipeList;
+import ymfc.storage.Storage;
+import ymfc.ui.Ui;
+
+import java.io.IOException;
+import java.util.logging.Level;
+import static ymfc.YMFC.logger;
+
+public class DeleteIngredientCommand extends Command {
+
+    public static final String USAGE_EXAMPLE = """
+            Use example:
+            \tdeleteI n/onions
+            """;
+
+    private String ingredientName;
+
+    public DeleteIngredientCommand(String ingredientName) {
+        super();
+
+        logger.log(Level.FINEST, "Creating DeleteIngredientCommmand");
+        assert ingredientName != null;
+        this.ingredientName = ingredientName;
+    }
+
+    public void execute(RecipeList recipes, IngredientList ingredients,
+                        Ui ui, Storage storage) throws InvalidArgumentException {
+        logger.log(Level.FINEST, "Executing DeleteIngredientCommand");
+        assert ingredients != null;
+
+        boolean isRemoved = ingredients.removeIngredientByName(ingredientName);
+        if (isRemoved) {
+            ui.printDeletedTask(ingredientName, recipes.getCounter());
+            try {
+                storage.saveIngredients(ingredients);
+            } catch (IOException exception) {
+                System.out.println(exception.getMessage());
+            }
+        } else {
+            throw new InvalidArgumentException("Ingredient not found: " + ingredientName);
+        }
+    }
+}

--- a/src/main/java/ymfc/list/IngredientList.java
+++ b/src/main/java/ymfc/list/IngredientList.java
@@ -24,11 +24,6 @@ public class IngredientList {
         return ingredients.get(id);
     }
 
-    public void removeIngredient(int id) {
-        assert !ingredients.isEmpty() : "List should not be empty when deleting ingredient";
-        ingredients.remove(id);
-    }
-
     public boolean removeIngredientByName(String name) {
         assert !ingredients.isEmpty() : "List should not be empty when deleting ingredient";
         assert name != null : "Ingredient name should not be null";

--- a/src/main/java/ymfc/list/IngredientList.java
+++ b/src/main/java/ymfc/list/IngredientList.java
@@ -24,10 +24,10 @@ public class IngredientList {
         return ingredients.get(id);
     }
 
-    /*public void removeIngredient(int id) {
+    public void removeIngredient(int id) {
         assert !ingredients.isEmpty() : "List should not be empty when deleting ingredient";
         ingredients.remove(id);
-    }*/
+    }
 
     public boolean removeIngredientByName(String name) {
         assert !ingredients.isEmpty() : "List should not be empty when deleting ingredient";

--- a/src/main/java/ymfc/list/RecipeList.java
+++ b/src/main/java/ymfc/list/RecipeList.java
@@ -24,11 +24,6 @@ public class RecipeList {
         return recipes.get(id);
     }
 
-    public void removeRecipe(int id) {
-        assert !recipes.isEmpty() : "List should not be empty when deleting recipe";
-        recipes.remove(id);
-    }
-
     public boolean removeRecipeByName(String name) {
         assert !recipes.isEmpty() : "List should not be empty when deleting recipe";
         assert name != null : "Recipe name should not be null";

--- a/src/main/java/ymfc/list/RecipeList.java
+++ b/src/main/java/ymfc/list/RecipeList.java
@@ -7,16 +7,13 @@ import java.util.Comparator;
 
 public class RecipeList {
     private ArrayList<Recipe> recipes;
-    private int counter;
 
     public RecipeList() {
-        counter = 0;
         recipes = new ArrayList<>();
     }
 
     public void addRecipe(Recipe recipe){
         this.recipes.add(recipe);
-        counter++;
     }
 
     public ArrayList<Recipe> getRecipes() {
@@ -28,18 +25,16 @@ public class RecipeList {
     }
 
     public void removeRecipe(int id) {
-        assert counter > 0 : "List should not be empty when deleting recipe";
+        assert !recipes.isEmpty() : "List should not be empty when deleting recipe";
         recipes.remove(id);
-        counter--;
     }
 
     public boolean removeRecipeByName(String name) {
-        assert counter > 0 : "List should not be empty when deleting recipe";
+        assert !recipes.isEmpty() : "List should not be empty when deleting recipe";
         assert name != null : "Recipe name should not be null";
         for (int i = 0; i < recipes.size(); i++) {
             if (recipes.get(i).getName().equalsIgnoreCase(name)) {
                 recipes.remove(i);
-                counter--;
                 return true;
             }
         }
@@ -47,7 +42,7 @@ public class RecipeList {
     }
 
     public boolean editRecipe(String name, Recipe editedRecipe) {
-        assert counter > 0 : "List should not be empty when editing recipe";
+        assert !recipes.isEmpty() : "List should not be empty when editing recipe";
         assert name != null : "Recipe name should not be null";
         // Find the index of the recipe to edit
         int index = -1;
@@ -66,7 +61,7 @@ public class RecipeList {
     }
 
     public int getCounter() {
-        return counter;
+        return recipes.size();
     }
 
     public void sortAlphabetically() {

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -23,10 +23,14 @@ import ymfc.list.IngredientList;
 import ymfc.list.RecipeList;
 import ymfc.recipe.Recipe;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import java.util.HashSet;
 
 /**
  * Parse user input commands

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -1,17 +1,6 @@
 package ymfc.parser;
 
-import ymfc.commands.Command;
-import ymfc.commands.AddRecipeCommand;
-import ymfc.commands.AddIngredientCommand;
-import ymfc.commands.ByeCommand;
-import ymfc.commands.DeleteCommand;
-import ymfc.commands.EditCommand;
-import ymfc.commands.FindCommand;
-import ymfc.commands.HelpCommand;
-import ymfc.commands.ListCommand;
-import ymfc.commands.ListIngredientsCommand;
-import ymfc.commands.SortCommand;
-import ymfc.commands.FindIngredCommand;
+import ymfc.commands.*;
 
 import ymfc.exception.EmptyListException;
 import ymfc.exception.InvalidArgumentException;
@@ -63,6 +52,11 @@ public final class Parser {
                 throw new EmptyListException("You can't remove something from nothing!");
             }
             return getDeleteCommand(args);
+        case "deleteI":
+            if (numIngredients <= 0) {
+                throw new EmptyListException("You can't remove something from nothing!");
+            }
+            return getDeleteIngredientCommand(args);
         case "listR":
             if (numRecipes <= 0) {
                 throw new EmptyListException("Your recipe list is empty!");
@@ -190,6 +184,19 @@ public final class Parser {
         }
         String name = m.group("name").trim().substring(2);
         return new DeleteCommand(name);
+    }
+
+    private static DeleteIngredientCommand getDeleteIngredientCommand(String args) throws InvalidArgumentException {
+        final Pattern deleteIngredientCommandFormat =
+                Pattern.compile("(?<name>[nN]/[^/]+)");
+        String input = args.trim();
+        Matcher m = deleteIngredientCommandFormat.matcher(input);
+        if (!m.matches()) {
+            throw new InvalidArgumentException("Invalid argument(s): " + input + "\n"
+                    + DeleteIngredientCommand.USAGE_EXAMPLE);
+        }
+        String name = m.group("name").trim().substring(2);
+        return new DeleteIngredientCommand(name);
     }
 
     private static SortCommand getSortCommand(String args) throws InvalidArgumentException {

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -1,6 +1,18 @@
 package ymfc.parser;
 
-import ymfc.commands.*;
+import ymfc.commands.Command;
+import ymfc.commands.DeleteCommand;
+import ymfc.commands.DeleteIngredientCommand;
+import ymfc.commands.ListCommand;
+import ymfc.commands.AddIngredientCommand;
+import ymfc.commands.SortCommand;
+import ymfc.commands.ByeCommand;
+import ymfc.commands.HelpCommand;
+import ymfc.commands.EditCommand;
+import ymfc.commands.FindCommand;
+import ymfc.commands.AddRecipeCommand;
+import ymfc.commands.ListIngredientsCommand;
+import ymfc.commands.FindIngredCommand;
 
 import ymfc.exception.EmptyListException;
 import ymfc.exception.InvalidArgumentException;

--- a/src/test/java/ymfc/list/IngredientListTest.java
+++ b/src/test/java/ymfc/list/IngredientListTest.java
@@ -3,8 +3,6 @@ package ymfc.list;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import ymfc.ingredient.Ingredient;
-import ymfc.recipe.Recipe;
-
 
 import java.util.ArrayList;
 

--- a/src/test/java/ymfc/list/IngredientListTest.java
+++ b/src/test/java/ymfc/list/IngredientListTest.java
@@ -30,7 +30,7 @@ public class IngredientListTest {
     }
 
     @Test
-    public void addRecipe_addingMultipleRecipes_success() {
+    public void addIngredient_addingMultipleIngredients_success() {
         testIngredientList = new IngredientList();
         assertEquals(0, testIngredientList.getCounter());
 
@@ -45,33 +45,33 @@ public class IngredientListTest {
     }
 
     @Test
-    public void removeRecipe_deletingMultipleRecipes_success() {
-        testIngredientList = new IngredientList();
-        testIngredientList.addIngredient(ingredient1);
-        testIngredientList.addIngredient(ingredient2);
-        testIngredientList.addIngredient(ingredient2);
-
-        testIngredientList.removeIngredient(0);
-        assertEquals(2, testIngredientList.getCounter());
-        assertSame(ingredient1, testIngredientList.getIngredient(1));
-
-        testIngredientList.removeIngredient(1);
-        assertEquals(1, testIngredientList.getCounter());
-        assertSame(ingredient2, testIngredientList.getIngredient(0));
-    }
-
-    @Test
-    public void removeRecipe_inputOutOfBounds_exceptionThrown() {
+    public void removeIngredient_deletingMultipleIngredient_success() {
         testIngredientList = new IngredientList();
         testIngredientList.addIngredient(ingredient1);
         testIngredientList.addIngredient(ingredient2);
         testIngredientList.addIngredient(ingredient3);
 
-        assertThrows(IndexOutOfBoundsException.class, () -> testIngredientList.removeIngredient(-1));
+        testIngredientList.removeIngredientByName("Mash Potatoes");
+        assertEquals(2, testIngredientList.getCounter());
+        assertSame(ingredient2, testIngredientList.getIngredient(1));
+
+        testIngredientList.removeIngredientByName("White Rice");
+        assertEquals(1, testIngredientList.getCounter());
+        assertSame(ingredient2, testIngredientList.getIngredient(0));
     }
 
     @Test
-    public void removeRecipeByName_deletingMultipleRecipes_success() {
+    public void removeIngredient_nonExistentIngredient_returnFalse() {
+        testIngredientList = new IngredientList();
+        testIngredientList.addIngredient(ingredient1);
+        testIngredientList.addIngredient(ingredient2);
+        testIngredientList.addIngredient(ingredient3);
+
+        assertFalse(testIngredientList.removeIngredientByName("Potato"));
+    }
+
+    @Test
+    public void removeIngredientByName_deletingMultipleIngredients_success() {
         testIngredientList = new IngredientList();
         testIngredientList.addIngredient(ingredient1);
         testIngredientList.addIngredient(ingredient2);

--- a/src/test/java/ymfc/list/IngredientListTest.java
+++ b/src/test/java/ymfc/list/IngredientListTest.java
@@ -1,0 +1,88 @@
+package ymfc.list;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import ymfc.ingredient.Ingredient;
+import ymfc.recipe.Recipe;
+
+
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class IngredientListTest {
+    private Ingredient ingredient1;
+    private Ingredient ingredient2;
+    private Ingredient ingredient3;
+
+    private IngredientList testIngredientList;
+
+    @BeforeEach
+    void setUp() {
+        ingredient1 = new Ingredient("White Rice");
+        ingredient2 = new Ingredient("Plain Bread");
+        ingredient3 = new Ingredient("Mash Potatoes");
+    }
+
+    @Test
+    public void getIngredients_emptyIngredientList_returnEmptyArrayList() {
+        assertEquals(new ArrayList<Ingredient>(), new IngredientList().getIngredients());
+    }
+
+    @Test
+    public void addRecipe_addingMultipleRecipes_success() {
+        testIngredientList = new IngredientList();
+        assertEquals(0, testIngredientList.getCounter());
+
+        testIngredientList.addIngredient(ingredient1);
+        assertEquals(1, testIngredientList.getCounter());
+
+        testIngredientList.addIngredient(ingredient2);
+        assertEquals(2, testIngredientList.getCounter());
+
+        testIngredientList.addIngredient(ingredient3);
+        assertEquals(3, testIngredientList.getCounter());
+    }
+
+    @Test
+    public void removeRecipe_deletingMultipleRecipes_success() {
+        testIngredientList = new IngredientList();
+        testIngredientList.addIngredient(ingredient1);
+        testIngredientList.addIngredient(ingredient2);
+        testIngredientList.addIngredient(ingredient2);
+
+        testIngredientList.removeIngredient(0);
+        assertEquals(2, testIngredientList.getCounter());
+        assertSame(ingredient1, testIngredientList.getIngredient(1));
+
+        testIngredientList.removeIngredient(1);
+        assertEquals(1, testIngredientList.getCounter());
+        assertSame(ingredient2, testIngredientList.getIngredient(0));
+    }
+
+    @Test
+    public void removeRecipe_inputOutOfBounds_exceptionThrown() {
+        testIngredientList = new IngredientList();
+        testIngredientList.addIngredient(ingredient1);
+        testIngredientList.addIngredient(ingredient2);
+        testIngredientList.addIngredient(ingredient3);
+
+        assertThrows(IndexOutOfBoundsException.class, () -> testIngredientList.removeIngredient(-1));
+    }
+
+    @Test
+    public void removeRecipeByName_deletingMultipleRecipes_success() {
+        testIngredientList = new IngredientList();
+        testIngredientList.addIngredient(ingredient1);
+        testIngredientList.addIngredient(ingredient2);
+        testIngredientList.addIngredient(ingredient3);
+
+        testIngredientList.removeIngredientByName(ingredient2.getName());
+        assertEquals(2, testIngredientList.getCounter());
+        assertSame(ingredient3, testIngredientList.getIngredient(1));
+
+        testIngredientList.removeIngredientByName(ingredient1.getName());
+        assertEquals(1, testIngredientList.getCounter());
+        assertSame(ingredient3, testIngredientList.getIngredient(0));
+    }
+}

--- a/src/test/java/ymfc/list/IngredientListTest.java
+++ b/src/test/java/ymfc/list/IngredientListTest.java
@@ -6,7 +6,9 @@ import ymfc.ingredient.Ingredient;
 
 import java.util.ArrayList;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class IngredientListTest {
     private Ingredient ingredient1;

--- a/src/test/java/ymfc/list/RecipeListTest.java
+++ b/src/test/java/ymfc/list/RecipeListTest.java
@@ -7,8 +7,9 @@ import java.util.ArrayList;
 
 import ymfc.recipe.Recipe;
 
-import static org.junit.jupiter.api.Assertions.*;
-
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RecipeListTest {
 

--- a/src/test/java/ymfc/list/RecipeListTest.java
+++ b/src/test/java/ymfc/list/RecipeListTest.java
@@ -2,13 +2,12 @@ package ymfc.list;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.ArrayList;
 
 import ymfc.recipe.Recipe;
+
+import static org.junit.jupiter.api.Assertions.*;
 
 
 public class RecipeListTest {
@@ -68,23 +67,23 @@ public class RecipeListTest {
         testRecipeList.addRecipe(recipe2);
         testRecipeList.addRecipe(recipe3);
 
-        testRecipeList.removeRecipe(0);
+        testRecipeList.removeRecipeByName(recipe1.getName());
         assertEquals(2, testRecipeList.getCounter());
         assertSame(recipe3, testRecipeList.getRecipe(1));
 
-        testRecipeList.removeRecipe(1);
+        testRecipeList.removeRecipeByName(recipe3.getName());
         assertEquals(1, testRecipeList.getCounter());
         assertSame(recipe2, testRecipeList.getRecipe(0));
     }
 
     @Test
-    public void removeRecipe_inputOutOfBounds_exceptionThrown() {
+    public void removeRecipe_nonExistentRecipe_returnFalse() {
         testRecipeList = new RecipeList();
         testRecipeList.addRecipe(recipe1);
         testRecipeList.addRecipe(recipe2);
         testRecipeList.addRecipe(recipe3);
 
-        assertThrows(IndexOutOfBoundsException.class, () -> testRecipeList.removeRecipe(-1));
+        assertFalse(testRecipeList.removeRecipeByName("Potato Salad"));
     }
 
 


### PR DESCRIPTION
Fixed issue #72: false behavior of add command
- Added new function in Parser to check that step number in user input when adding recipe:
    - Does not skip numbers
    - Does not contain identical numbers

- Implemented feature #76 
    - Added deleteIngredientCommand class and implemented deleteIngredient
    - use case: "deleteI n/potato"

- Remove unecessary methods removeIngredient() and removeRecipe() in IngredientList and RecipeList classes
- Wrote tests for IngredientList, and updated tests for RecipeList

