### PR TITLE
Fix leading spaces bug in delete commands, fix incorrect UI when deleteI command is executed

### DIFF
--- a/src/main/java/ymfc/commands/DeleteIngredientCommand.java
+++ b/src/main/java/ymfc/commands/DeleteIngredientCommand.java
@@ -34,7 +34,7 @@ public class DeleteIngredientCommand extends Command {
 
         boolean isRemoved = ingredients.removeIngredientByName(ingredientName);
         if (isRemoved) {
-            ui.printDeletedTask(ingredientName, recipes.getCounter());
+            ui.printDeletedIngredient(ingredientName, ingredients.getCounter());
             try {
                 storage.saveIngredients(ingredients);
             } catch (IOException exception) {

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -236,7 +236,7 @@ public final class Parser {
             throw new InvalidArgumentException("Invalid argument(s): " + input + "\n" + DeleteCommand.USAGE_EXAMPLE);
         }
         String name = m.group("name").trim().substring(2);
-        return new DeleteCommand(name);
+        return new DeleteCommand(name.trim());
     }
 
     private static DeleteIngredientCommand getDeleteIngredientCommand(String args) throws InvalidArgumentException {
@@ -249,7 +249,7 @@ public final class Parser {
                     + DeleteIngredientCommand.USAGE_EXAMPLE);
         }
         String name = m.group("name").trim().substring(2);
-        return new DeleteIngredientCommand(name);
+        return new DeleteIngredientCommand(name.trim());
     }
 
     private static SortCommand getSortCommand(String args) throws InvalidArgumentException {

--- a/src/main/java/ymfc/ui/Ui.java
+++ b/src/main/java/ymfc/ui/Ui.java
@@ -204,7 +204,22 @@ public class Ui {
         System.out.println("\t  " + deletedRecipe);
         // Conditional operator to pluralize "recipe" when listCount above 1
         System.out.println("\tYou currently have " + listCount +
-                (listCount <= 1 ? " recipe" : " recipes") + " in your list.");
+                (listCount == 1 ? " recipe" : " recipes") + " in your list.");
+        System.out.println(LINE);
+    }
+
+    /**
+     * Display an ingredient that been deleted.
+     *
+     * @param deletedIngredient Ingredient that has been deleted.
+     * @param listCount Integer representing number of ingredients in the list currently.
+     */
+    public void printDeletedIngredient(String deletedIngredient, int listCount) {
+        System.out.println(LINE);
+        System.out.println("\tAww, I shall begrudgingly let go of this ingredient:");
+        System.out.println("\t  " + deletedIngredient);
+        System.out.println("\tYou currently have " + listCount +
+                (listCount == 1 ? " ingredient" : " ingredients") + " in your list.");
         System.out.println(LINE);
     }
 

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -260,9 +260,9 @@
 
 	__________________________________________________________________________________
 	__________________________________________________________________________________
-	Aww, I shall begrudgingly let go of this recipe:
+	Aww, I shall begrudgingly let go of this ingredient:
 	  eggs
-	You currently have 2 recipes in your list.
+	You currently have 2 ingredients in your list.
 	__________________________________________________________________________________
 	__________________________________________________________________________________
                  (\


### PR DESCRIPTION
`delete` and `deleteI` now will match the recipes and ingredients to be deleted if leading spaces are inputted by the user. The UI print statements when an ingredient is deleted is also updated
Should resolve #193, #196 and #199