### PR TITLE
Improve edit command functionality

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -234,6 +234,8 @@ Will find the recipe of the entered name and change its parameters to the newly 
 - All parameters are optional except for `e/NAME`, leaving any of the optional parameters out of the command means 
 the existing parameters of that type is untouched (e.g. don't need to add `c/CUISINE` to your command if you 
 wish to keep the cuisine parameter of the recipe unedited).
+- However, leaving every single optional parameter out will basically do nothing, 
+so that isn't really an edit now, is it? (You will get a reminder from YMFC for this)
 - The `e/NAME` refers to the current name of the recipe you wish to edit
 - The `n/NAME` refers to the new name you wish to rename the recipe to
 - The `i/INGREDIENTS...` refers to the new list of ingredients for the recipe (note that the entire current list of  

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -228,10 +228,24 @@ ________________________________________________________________________________
 
 ### Editing an existing Recipe
 
-Format: `edit e/NAME i/INGREDIENTS... sn/STEPn... [c/CUISINE] [t/TIME]`
+Format: `edit e/NAME [n/NAME] [i/INGREDIENTS...] [sn/STEPn...] [c/CUISINE] [t/TIME]`
 
-Will find the recipe of the entered name and change its details to the newly entered parameters
-* The name of the recipe cannot be changed, only it's details (ingredients, steps, cuisine, time)
+Will find the recipe of the entered name and change its parameters to the newly entered parameters.
+- All parameters are optional except for `e/NAME`, leaving any of the optional parameters out of the command means 
+the existing parameters of that type is untouched (e.g. don't need to add `c/CUISINE` to your command if you 
+wish to keep the cuisine parameter of the recipe unedited).
+- The `e/NAME` refers to the current name of the recipe you wish to edit
+- The `n/NAME` refers to the new name you wish to rename the recipe to
+- The `i/INGREDIENTS...` refers to the new list of ingredients for the recipe (note that the current list of all 
+ingredients for the recipe is overwritten with the new list inputted)
+- The `sn/STEPn...` refers to the new list of steps for the recipe (note that the current list of all
+steps for the recipe is overwritten with the new list inputted)
+- The `c/CUISINE` refers to the new cuisine you wish to edit the recipe to have, leaving CUISINE blank
+(e.g. typing `c/ `) will delete the existing cuisine parameter of the recipe
+- The `t/TIME` refers to the new time taken you wish to edit the recipe to have, leaving TIME blank
+(e.g. typing `c/ `) will delete the existing time parameter of the recipe
+* Parameters follow the same rule as adding a new recipe
+* Existing recipes cannot be renamed to a name already used by another recipe (this is case-insensitive)
 
 Example of usage:
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -236,9 +236,9 @@ the existing parameters of that type is untouched (e.g. don't need to add `c/CUI
 wish to keep the cuisine parameter of the recipe unedited).
 - The `e/NAME` refers to the current name of the recipe you wish to edit
 - The `n/NAME` refers to the new name you wish to rename the recipe to
-- The `i/INGREDIENTS...` refers to the new list of ingredients for the recipe (note that the current list of all 
+- The `i/INGREDIENTS...` refers to the new list of ingredients for the recipe (note that the entire current list of  
 ingredients for the recipe is overwritten with the new list inputted)
-- The `sn/STEPn...` refers to the new list of steps for the recipe (note that the current list of all
+- The `sn/STEPn...` refers to the new list of steps for the recipe (note that the entire current list of 
 steps for the recipe is overwritten with the new list inputted)
 - The `c/CUISINE` refers to the new cuisine you wish to edit the recipe to have, leaving CUISINE blank
 (e.g. typing `c/ `) will delete the existing cuisine parameter of the recipe

--- a/src/main/java/ymfc/commands/EditCommand.java
+++ b/src/main/java/ymfc/commands/EditCommand.java
@@ -45,7 +45,7 @@ public class EditCommand extends Command {
         this.newTimeTaken = newTimeTaken;
     }
 
-    public Recipe craftEditedRecipe(Recipe toEditRecipe) {
+    private Recipe craftEditedRecipe(Recipe toEditRecipe) {
         // Use new recipe parameters if they are specified (not null), else use original parameters
         String editedName;
         ArrayList<Ingredient> editedIngredients;
@@ -93,10 +93,19 @@ public class EditCommand extends Command {
         return new Recipe(editedName,editedIngredients, editedSteps, editedCuisine, editedTimeTaken);
     }
 
+    private boolean isDuplicateRecipe(String recipeName, RecipeList recipes) {
+        for (int i = 0; i < recipes.getCounter(); i++) {
+            if (recipes.getRecipe(i).getName().toLowerCase().equals(recipeName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
     /**
      * Executes the {@code EditCommand}, finding a recipe matching the name inputted by the user
      * and then editing it based on the new parameters inputted. If the recipe of the specified name
-     * is found and then editted, the {@code Storage} is updated and a confirmation message is displayed.
+     * is found and then edited, the {@code Storage} is updated and a confirmation message is displayed.
      *
      * @param recipes The {@code RecipeList} to edit the recipe from. Must not be {@code null}.
      * @param ingredients The {@code IngredientList}. Unused in this command.
@@ -109,6 +118,10 @@ public class EditCommand extends Command {
         logger.log(Level.FINEST, "Executing EditCommand");
         assert matchName != null;
 
+        // If newName is a duplicate of an existing recipe name, throw error
+        if (newName!= null && isDuplicateRecipe(newName.toLowerCase(), recipes)) {
+            throw new InvalidArgumentException("Hey that new name already belongs to an existing recipe.");
+        }
         // Find recipe in recipes that match the name of recipe to edit
         int toEditRecipeIndex = recipes.getIndexByName(matchName);
         if (toEditRecipeIndex < 0) {

--- a/src/main/java/ymfc/commands/EditCommand.java
+++ b/src/main/java/ymfc/commands/EditCommand.java
@@ -93,9 +93,12 @@ public class EditCommand extends Command {
         return new Recipe(editedName, editedIngredients, editedSteps, editedCuisine, editedTimeTaken);
     }
 
-    private boolean isDuplicateRecipe(String recipeName, RecipeList recipes) {
+    private boolean isNameTaken(RecipeList recipes) {
+        if (newName.equalsIgnoreCase(matchName)) {
+            return false;
+        }
         for (int i = 0; i < recipes.getCounter(); i++) {
-            if (recipes.getRecipe(i).getName().toLowerCase().equals(recipeName)) {
+            if (recipes.getRecipe(i).getName().equalsIgnoreCase(newName)) {
                 return true;
             }
         }
@@ -118,10 +121,6 @@ public class EditCommand extends Command {
         logger.log(Level.FINEST, "Executing EditCommand");
         assert matchName != null;
 
-        // If newName is a duplicate of an existing recipe name, throw error
-        if (newName!= null && isDuplicateRecipe(newName.toLowerCase(), recipes)) {
-            throw new InvalidArgumentException("Hey that new name already belongs to an existing recipe.");
-        }
         // Find recipe in recipes that match the name of recipe to edit
         int toEditRecipeIndex = recipes.getIndexByName(matchName);
         if (toEditRecipeIndex < 0) {
@@ -129,6 +128,13 @@ public class EditCommand extends Command {
         }
         Recipe toEditRecipe = recipes.getRecipe(toEditRecipeIndex);
         String originalName = toEditRecipe.getName();
+
+        // If newName is already taken by an existing recipe name that isn't matchName, throw error
+        if (newName != null) {
+            if (isNameTaken(recipes)) {
+                throw new InvalidArgumentException("Hey that new name already belongs to another existing recipe.");
+            }
+        }
 
         // Craft edited recipe based on pre-existing recipe and parameters to edit
         Recipe editedRecipe = craftEditedRecipe(toEditRecipe);

--- a/src/main/java/ymfc/commands/EditCommand.java
+++ b/src/main/java/ymfc/commands/EditCommand.java
@@ -33,7 +33,7 @@ public class EditCommand extends Command {
     private Integer newTimeTaken;
 
     public EditCommand(String matchName, String newName, ArrayList<Ingredient> newIngredients,
-                       ArrayList<String> newSteps,String newCuisine, Integer newTimeTaken) {
+                       ArrayList<String> newSteps, String newCuisine, Integer newTimeTaken) {
         super();
         logger.log(Level.FINEST, "Creating EditCommand");
         assert matchName != null;
@@ -90,7 +90,7 @@ public class EditCommand extends Command {
             }
         }
 
-        return new Recipe(editedName,editedIngredients, editedSteps, editedCuisine, editedTimeTaken);
+        return new Recipe(editedName, editedIngredients, editedSteps, editedCuisine, editedTimeTaken);
     }
 
     private boolean isDuplicateRecipe(String recipeName, RecipeList recipes) {

--- a/src/main/java/ymfc/list/RecipeList.java
+++ b/src/main/java/ymfc/list/RecipeList.java
@@ -36,23 +36,22 @@ public class RecipeList {
         return false;
     }
 
-    public boolean editRecipe(String name, Recipe editedRecipe) {
+    public int getIndexByName(String matchName) {
         assert !recipes.isEmpty() : "List should not be empty when editing recipe";
-        assert name != null : "Recipe name should not be null";
+        assert matchName != null : "Recipe name should not be null";
         // Find the index of the recipe to edit
         int index = -1;
         for (int i = 0; i < recipes.size(); i++) {
-            if (recipes.get(i).getName().equalsIgnoreCase(name)) {
+            if (recipes.get(i).getName().equalsIgnoreCase(matchName)) {
                 index = i;
                 break;
             }
         }
-        // If index not found, return false, else edit the recipe based on index found
-        if (index == -1) {
-            return false;
-        }
-        recipes.set(index, editedRecipe);
-        return true;
+        return index;
+    }
+
+    public void updateRecipe(int index, Recipe recipe) {
+        recipes.set(index, recipe);
     }
 
     public int getCounter() {

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -341,32 +341,22 @@ public final class Parser {
      * @throws InvalidArgumentException If invalid format of arguments is found
      */
     private static EditCommand getEditCommand(String args) throws InvalidArgumentException {
-        /*final Pattern editCommandFormat =
-                // <e or E>/<String without forward slash>
-                Pattern.compile("(?<name>[eE]/[^/]+)"
-                        // Match ingredients: at least one i/ or I/ followed by any characters except '/'
-                        + "(?<ingreds>(\\s+[iI]/[^/]+)+)"
-                        // Match steps: at least one sX/ or SX/ (X is a number) followed by any characters except '/'
-                        + "(?<steps>(\\s+[sS][0-9]+/[^/]+)+)"
-                        // Match optional cuisine: c/ or C/ followed by any characters except '/'
-                        + "(\\s+(?<cuisine>[cC]/[^/]+))?"
-                        // Match optional time taken: t/ or T/ followed by digits
-                        + "(\\s+(?<time>[tT]/\\s*[0-9]+))?");*/
-
-        // Pattern for an edit command, everything is optional except for naming the recipe to edit
+        // Pattern for an edit command, everything is optional except for the name of the recipe to be edited
         final Pattern editCommandFormat =
                 // <e or E>/<String without forward slash>
                 Pattern.compile("(?<matchName>[eE]/[^/]+)"
                         // Match optional new name: n/ or N/ followed by any characters except '/'
-                        + "(?<newName>[nN]/[^/]+)?"
+                        + "(\\s+(?<newName>[nN]/[^/]+))?"
                         // Match optional ingredients: i/ or I/ followed by any characters except '/'
                         + "(?<ingreds>(\\s+[iI]/[^/]+)+)?"
                         // Match optional steps: sX/ or SX/ (X is a number) followed by any characters except '/'
                         + "(?<steps>(\\s+[sS][0-9]+/[^/]+)+)?"
                         // Match optional cuisine: c/ or C/ followed by any characters except '/'
+                        // Accepts empty field after c/ or C/ to indicate no cuisine
                         + "(\\s+(?<cuisine>[cC]/[^/]*))?"
                         // Match optional time taken: t/ or T/ followed by digits
-                        + "(\\s+(?<time>[tT]/\\s*[0-9]+))?");
+                        // Accepts empty field after t/ T/ to indicate no time
+                        + "(\\s+(?<time>[tT]/\\s*[0-9]*))?");
 
         String input = args.trim();
         Matcher m = editCommandFormat.matcher(input);
@@ -374,42 +364,70 @@ public final class Parser {
             throw new InvalidArgumentException("Invalid argument(s): " + input + "\n" + EditCommand.USAGE_EXAMPLE);
         }
 
+        // Get the name of the recipe to be edited
         String matchName = m.group("matchName").trim().substring(2).trim(); // e/ or E/ are 2 chars
+
+        // Get optional new name to replace the existing one
         String newName = null;
         String newNameInput = m.group("newName");
         if (newNameInput != null) {
             newName = newNameInput.trim().substring(2).trim(); // e/ or E/ are 2 chars
         }
+
+        // Get optional new ingredient list to replace the existing one
         String ingredString = m.group("ingreds");
+        ArrayList<Ingredient> ingreds = null;
+        if (ingredString != null) {
+            ingreds = Arrays.stream(ingredString.split("\\s+[iI]/"))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .map(Ingredient::new)
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
+
+        // Get optional new steps list to replace the existing one
         String stepString = m.group("steps");
-        ArrayList<Ingredient> ingreds = Arrays.stream(ingredString.split("\\s+[iI]/"))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .map(Ingredient::new)
-                .collect(Collectors.toCollection(ArrayList::new));
-        ArrayList<String> steps = Arrays.stream(stepString.split("\\s+[sS][0-9]+/"))
-                .map(String::trim)
-                .filter(s -> !s.isEmpty())
-                .collect(Collectors.toCollection(ArrayList::new));
+        ArrayList<String> steps = null;
+        if (stepString != null) {
+            //@@author gskang
+            // Extract step identifiers (s1, s2, ...) and validate for duplicates or missing numbers
+            List<String> stepIdentifiers = Arrays.stream(stepString.split("\\s+"))
+                    .filter(step -> step.matches("[sS][0-9]+/.*")) // Ensure the string matches the step format
+                    .map(step -> step.split("/")[0]) // Extracts "s1", "s2", etc.
+                    .toList();
 
-        //@@author gskang
-        // Extract step identifiers (s1, s2, ...) and validate for duplicates or missing numbers
-        List<String> stepIdentifiers = Arrays.stream(stepString.split("\\s+"))
-                .filter(step -> step.matches("[sS][0-9]+/.*")) // Ensure the string matches the step format
-                .map(step -> step.split("/")[0]) // Extracts "s1", "s2", etc.
-                .toList();
+            validateStepNumbers(stepIdentifiers); // Check for missing/duplicate numbers
+            //@@author
 
-        validateStepNumbers(stepIdentifiers); // Check for missing/duplicate numbers
-        //@@author
+            steps = Arrays.stream(stepString.split("\\s+[sS][0-9]+/"))
+                    .map(String::trim)
+                    .filter(s -> !s.isEmpty())
+                    .collect(Collectors.toCollection(ArrayList::new));
+        }
 
+        // Get optional new cuisine to replace the existing one
         String cuisineInput = m.group("cuisine");
         String cuisine = null;
         if (cuisineInput != null) {
+            // Trim all leading whitespaces from cuisineInput
+            String trimmedCuisineInput = cuisineInput.replaceAll("^\\s+", "");
             cuisine = cuisineInput.trim().substring(2).trim();
         }
-        Integer timeTaken = getTimeTakenInteger(m);
 
-        return new EditCommand(new Recipe(matchName, ingreds, steps, cuisine, timeTaken));
+        // Get optional new time to replace the existing one
+        String timeInput = m.group("time");
+        Integer timeTaken = null;
+        if (timeInput != null) {
+            // Remove t/ or T/ from the timeInput
+            String timeInputEdited = timeInput.replaceAll("[tT]/", "");
+            if (timeInputEdited.trim().isEmpty()) {
+                timeTaken = -1; // Negative invalid TimeTaken to indicate deletion later on
+            } else {
+                timeTaken = getTimeTakenInteger(m);
+            }
+        }
+
+        return new EditCommand(matchName, newName, ingreds, steps, cuisine, timeTaken);
     }
 
     private static Command getFindCommand(String args) throws InvalidArgumentException {

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -341,7 +341,7 @@ public final class Parser {
      * @throws InvalidArgumentException If invalid format of arguments is found
      */
     private static EditCommand getEditCommand(String args) throws InvalidArgumentException {
-        final Pattern editCommandFormat =
+        /*final Pattern editCommandFormat =
                 // <e or E>/<String without forward slash>
                 Pattern.compile("(?<name>[eE]/[^/]+)"
                         // Match ingredients: at least one i/ or I/ followed by any characters except '/'
@@ -351,6 +351,21 @@ public final class Parser {
                         // Match optional cuisine: c/ or C/ followed by any characters except '/'
                         + "(\\s+(?<cuisine>[cC]/[^/]+))?"
                         // Match optional time taken: t/ or T/ followed by digits
+                        + "(\\s+(?<time>[tT]/\\s*[0-9]+))?");*/
+
+        // Pattern for an edit command, everything is optional except for naming the recipe to edit
+        final Pattern editCommandFormat =
+                // <e or E>/<String without forward slash>
+                Pattern.compile("(?<matchName>[eE]/[^/]+)"
+                        // Match optional new name: n/ or N/ followed by any characters except '/'
+                        + "(?<newName>[nN]/[^/]+)?"
+                        // Match optional ingredients: i/ or I/ followed by any characters except '/'
+                        + "(?<ingreds>(\\s+[iI]/[^/]+)+)?"
+                        // Match optional steps: sX/ or SX/ (X is a number) followed by any characters except '/'
+                        + "(?<steps>(\\s+[sS][0-9]+/[^/]+)+)?"
+                        // Match optional cuisine: c/ or C/ followed by any characters except '/'
+                        + "(\\s+(?<cuisine>[cC]/[^/]*))?"
+                        // Match optional time taken: t/ or T/ followed by digits
                         + "(\\s+(?<time>[tT]/\\s*[0-9]+))?");
 
         String input = args.trim();
@@ -359,7 +374,12 @@ public final class Parser {
             throw new InvalidArgumentException("Invalid argument(s): " + input + "\n" + EditCommand.USAGE_EXAMPLE);
         }
 
-        String name = m.group("name").trim().substring(2); // e/ or E/ are 2 chars
+        String matchName = m.group("matchName").trim().substring(2).trim(); // e/ or E/ are 2 chars
+        String newName = null;
+        String newNameInput = m.group("newName");
+        if (newNameInput != null) {
+            newName = newNameInput.trim().substring(2).trim(); // e/ or E/ are 2 chars
+        }
         String ingredString = m.group("ingreds");
         String stepString = m.group("steps");
         ArrayList<Ingredient> ingreds = Arrays.stream(ingredString.split("\\s+[iI]/"))
@@ -389,7 +409,7 @@ public final class Parser {
         }
         Integer timeTaken = getTimeTakenInteger(m);
 
-        return new EditCommand(new Recipe(name, ingreds, steps, cuisine, timeTaken));
+        return new EditCommand(new Recipe(matchName, ingreds, steps, cuisine, timeTaken));
     }
 
     private static Command getFindCommand(String args) throws InvalidArgumentException {

--- a/src/main/java/ymfc/parser/Parser.java
+++ b/src/main/java/ymfc/parser/Parser.java
@@ -427,6 +427,12 @@ public final class Parser {
             }
         }
 
+        // If all optional parameters are null, inform the user
+        if (newName == null && ingreds == null && steps == null && cuisine == null && timeTaken == null) {
+            throw new InvalidArgumentException("So you are giving me nothing to edit about your recipe?"
+                    + System.lineSeparator() + "Look up what \"edit\" means in the dictionary.");
+        }
+
         return new EditCommand(matchName, newName, ingreds, steps, cuisine, timeTaken);
     }
 

--- a/src/main/java/ymfc/ui/Ui.java
+++ b/src/main/java/ymfc/ui/Ui.java
@@ -298,7 +298,7 @@ public class Ui {
     }
 
     /**
-     * Display list of inrgedients with order of each ingredient.
+     * Display list of ingredients with order of each ingredient.
      *
      * @param list ArrayList of ingredients to be displayed.
      * @param listCount Integer representing total number of ingredients in <code>list</code>.

--- a/src/test/java/ymfc/commands/EditCommandTest.java
+++ b/src/test/java/ymfc/commands/EditCommandTest.java
@@ -51,14 +51,15 @@ public class EditCommandTest {
         addCommand = new AddCommand(recipe);
         nonEmptyList.addRecipe(recipe);
 
-        // Sample ingredients and steps
+        // Sample edited steps
         ArrayList<String> newSteps = new ArrayList<>();
         newSteps.add("boil water");
         newSteps.add("eat magi mee");
         newSteps.add("drink water");
 
         editedRecipe = new Recipe("instant noodles", ingredients, newSteps);
-        editCommand = new EditCommand(editedRecipe);
+        editCommand = new EditCommand("instant noodles", null, null,
+                newSteps, null, null);
     }
 
     @Test
@@ -70,13 +71,14 @@ public class EditCommandTest {
 
         editCommand.execute(emptyList, ingredientList, ui, storage);
         assertEquals(1, emptyList.getCounter());
-        assertEquals(edittedRecipe, emptyList.getRecipe(0));
+        assertEquals(editedRecipe.toString(), emptyList.getRecipe(0).toString());
     }
 
     @Test
     void testEditRecipe_fail() {
-        Recipe dummyRecipe = new Recipe("ramen", new ArrayList<Ingredient>(), new ArrayList<String>());
+        EditCommand dummyEditCommand = new EditCommand("ramen", null, null,
+                null, null, null);
         assertThrows(InvalidArgumentException.class,
-                () -> new EditCommand(dummyRecipe).execute(nonEmptyList, ingredientList, ui, storage));
+                () -> dummyEditCommand.execute(nonEmptyList, ingredientList, ui, storage));
     }
 }

--- a/src/test/java/ymfc/commands/EditCommandTest.java
+++ b/src/test/java/ymfc/commands/EditCommandTest.java
@@ -25,7 +25,7 @@ public class EditCommandTest {
     private IngredientList ingredientList;
     private Ui ui;
     private Recipe recipe;
-    private Recipe edittedRecipe;
+    private Recipe editedRecipe;
     private AddCommand addCommand;
     private EditCommand editCommand;
 
@@ -57,8 +57,8 @@ public class EditCommandTest {
         newSteps.add("eat magi mee");
         newSteps.add("drink water");
 
-        edittedRecipe = new Recipe("instant noodles", ingredients, newSteps);
-        editCommand = new EditCommand(edittedRecipe);
+        editedRecipe = new Recipe("instant noodles", ingredients, newSteps);
+        editCommand = new EditCommand(editedRecipe);
     }
 
     @Test

--- a/src/test/java/ymfc/parser/ParserTest.java
+++ b/src/test/java/ymfc/parser/ParserTest.java
@@ -476,7 +476,14 @@ class ParserTest {
     @ParameterizedTest
     @DisplayName("parseCommand_editCommand_success")
     @ValueSource(strings = {
-        "edit e/Pasta i/Potato i/Tomato i/Pasta s1/Boil pasta in water s2/Ice bath the pasta"
+        "edit e/Pasta i/Potato i/Tomato i/Pasta s1/Boil pasta in water s2/Ice bath the pasta",
+        "edit e/Pasta",
+        "edit e/Pasta i/Potato i/Tomato",
+        "edit e/Pasta s1/Boil pasta in water s2/Ice bath the pasta",
+        "edit e/Pasta c/Italian",
+        "edit e/Pasta c/",
+        "edit e/Pasta t/5",
+        "edit e/Pasta t/"
     })
     void parseCommand_editCommand_success(String command) {
         try {
@@ -498,30 +505,18 @@ class ParserTest {
     @ParameterizedTest
     @DisplayName("parseCommand_editCommand_invalidArgumentExceptionThrown")
     @ValueSource(strings = {
-        "edit e/Plain Water",                                                            // Missing ingreds and steps
-        "edit e/Salad i/lettuce i/tomato i/cucumber",                                    // Missing steps
-        "edit e/Walking s1/start walking s2/keep walking",                               // Missing ingreds
         "edit i/eggs i/milk s1/whisk together",                                          // Missing name
-        "edit e/Toast bread butter s1/spread butter on bread",                           // Missing i/
-        "edit e/Smoothie i/banana i/yogurt blend all ingredients",                       // Missing s/
         "edit e/Pizza i/dough i/cheese s1/make dough s1/bake pizza",                     // Repeated step numbers
         "edit e/Sandwich i/bread i/ham i/cheese s1/spread butter s3/grill sandwich",     // Steps not in order
         "edit e/Soup i/ i/onion s1/cook onions s2/",                                     // Empty ingredient or step
         "edit e/  Porridge  i/ oats  i/milk s1 / cook oats",                             // Whitespace before slash
         "edit nPorridge i oats i milk s1 cook oats",                                     // No slashes
         "edit e//Omelette i/eggs// s1/fry/",                                             // Too many slashes
-        "edit e/RamenEggs i/eggsi/soya sauce i/water s1/boil eggss2/eggs in ice bath",    // Missing spaces
+        "edit e/RamenEggs i/eggsi/soya sauce i/water s1/boil eggss2/eggs in ice bath",   // Missing spaces
 
         // Test cases for invalid cuisine and time
-        "edit e/Spicy Wings i/chicken wings 5pcs c/Asian",                               // Missing steps and time
-        "edit e/Grilled Vegetable Salad i/zucchini i/bell pepper c/Mediterranean t/10",  // Missing steps
-        "edit e/Spicy Wings c/Asian t/15",                                               // Missing ingredient and step
-        "edit e/Salad i/lettuce i/tomato c/Healthy",                                     // Missing steps
         "edit e/Pasta i/pasta i/sauce s1/cook pasta c/Italian t/abc",                    // Invalid time format
-        "edit e/Smoothie i/banana i/yogurt blend all ingredients c/Fruit t/5",           // Missing steps
-        "edit e/Breakfast c/English",                                                    // Missing ingredient and step
         "edit e/Omelette i/eggs c/Breakfast s1/fry t/-10",                               // Invalid time (negative)
-        "edit e/Pancakes i/flour i/milk s1/mix c/Breakfast t/",                          // Missing time
         "edit e/Sandwich i/bread i/ham s1/spread butter c/Quick t/0"                     // Invalid time (zero)
     })
     void parseCommand_editCommand_invalidArgumentsExceptionThrown(String command) {

--- a/src/test/java/ymfc/parser/ParserTest.java
+++ b/src/test/java/ymfc/parser/ParserTest.java
@@ -477,7 +477,6 @@ class ParserTest {
     @DisplayName("parseCommand_editCommand_success")
     @ValueSource(strings = {
         "edit e/Pasta i/Potato i/Tomato i/Pasta s1/Boil pasta in water s2/Ice bath the pasta",
-        "edit e/Pasta",
         "edit e/Pasta i/Potato i/Tomato",
         "edit e/Pasta s1/Boil pasta in water s2/Ice bath the pasta",
         "edit e/Pasta c/Italian",
@@ -513,6 +512,7 @@ class ParserTest {
         "edit nPorridge i oats i milk s1 cook oats",                                     // No slashes
         "edit e//Omelette i/eggs// s1/fry/",                                             // Too many slashes
         "edit e/RamenEggs i/eggsi/soya sauce i/water s1/boil eggss2/eggs in ice bath",   // Missing spaces
+        "edit e/Pasta",                                                                  // No changes made
 
         // Test cases for invalid cuisine and time
         "edit e/Pasta i/pasta i/sauce s1/cook pasta c/Italian t/abc",                    // Invalid time format

--- a/text-ui-test/EXPECTED.TXT
+++ b/text-ui-test/EXPECTED.TXT
@@ -194,6 +194,8 @@
 	    1. saute garlic in oil
 	    2. boil paste
 	    3. add pasta to garlic and mix
+	  Cuisine: Italian
+	  Time taken: 15
 	__________________________________________________________________________________
 	__________________________________________________________________________________
 	Aww, I shall begrudgingly let go of this recipe:
@@ -257,6 +259,8 @@
 	    1. saute garlic in oil
 	    2. boil paste
 	    3. add pasta to garlic and mix
+	  Cuisine: Italian
+	  Time taken: 15
 
 	__________________________________________________________________________________
 	__________________________________________________________________________________


### PR DESCRIPTION
Fixes #209.
Fixes #189.
Fixes #183.
Fixes #178.
Fixes #171.

The inner working of the edit command is now revamped. Instead of forcing the user to type out all relevant parameters of a new recipe and overwriting an existing recipe of the same name with this new recipe, the edit command now works on a different principle.

- User just needs to state which recipe they want to edit by name, and then only have to type out the necessary types of parameters they wish to modify. For example, the user can modify only ingredients without affecting any other parameters, or only modify steps and cuisine. 
- However, all the parameters of the same type must be edited together (e.g. all steps are to be modified at once instead of only selectively modifying individual steps).
- User can now also change the name of existing recipes
- The deletion of optional parameters (cuisine, time taken) are also now permitted, by leaving the phrase after "c/" and "t/" blank when executing an edit command.

Example:
`edit e/egg mayonnaise n/egg mayo i/egg i/mayo c/ t/5`
Will find the recipe called "egg mayonnaise", change the name to "egg mayo", replace the old list of ingredients with a new list of "egg" and "mayo", remove the cuisine parameter of the recipe, set the time of the recipe to 5.