### PR TITLE
Fix some diagram-related minor and critical details of `AddRecipe.puml`

### DIFF
--- a/docs/puml/SequenceDiagrams/AddRecipes.puml
+++ b/docs/puml/SequenceDiagrams/AddRecipes.puml
@@ -14,7 +14,7 @@ box Adding Recipes COLOR_PALE_PINK
 participant "YMFC" as YMFC <<class>>
 participant "Parser" as Parser <<class>>
 participant ":AddCommand" as AddRecipeCommand
-participant ":Recipe" as Recipe
+participant "recipe:Recipe" as Recipe
 participant ":Storage" as Storage
 participant ":RecipeList" as RecipeList
 participant ":Storage" as Storage

--- a/docs/puml/SequenceDiagrams/AddRecipes.puml
+++ b/docs/puml/SequenceDiagrams/AddRecipes.puml
@@ -30,7 +30,7 @@ activate Parser
 create Recipe
 Parser -> Recipe : Recipe(name, ingreds, steps, cuisine, timeTaken)
 activate Recipe
-Recipe -> Parser : recipe:Recipe
+Recipe --> Parser : recipe:Recipe
 deactivate Recipe
 
 create AddRecipeCommand

--- a/docs/puml/SequenceDiagrams/AddRecipes.puml
+++ b/docs/puml/SequenceDiagrams/AddRecipes.puml
@@ -84,6 +84,8 @@ AddRecipeCommand --> AddRecipeCommand
 deactivate AddRecipeCommand
 AddRecipeCommand --> YMFC
 deactivate AddRecipeCommand
+AddRecipeCommand -[hidden]-> YMFC
+
 
 destroy AddRecipeCommand
 


### PR DESCRIPTION
Resolves #205, #194 

I basically add a hyphen, and problem solved! 💀 

Changes:
- Return arrow of `recipe:Recipe` in `AddRecipes` sequence diagram is now a dotted line. (#205)
- `:AddCommand` lifeline extends a bit further before terminating (Related to #195)
- `:Recipe` instance changed into `recipe:Recipe` (#194)